### PR TITLE
add include_image_data properties to kibela_get_note_content and kibela_get_note_from_path for avoiding heavy context

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Get your latest notes from Kibela
 Get content and comments of a specific note
 - Input:
   - `id` (string): Note ID
+  - `include_image_data` (boolean, optional): Whether to include image data URLs in the response (default: false)
 - Returns: Full note content including HTML, comments, attachments, groups, folders and more
 
 ### kibela_get_groups
@@ -153,6 +154,7 @@ Get your recently viewed notes
 Get note content by its path or URL
 - Input:
   - `path` (string): Note path (e.g. '/group/folder/note') or full Kibela URL (e.g. 'https://team.kibe.la/notes/123')
+  - `include_image_data` (boolean, optional): Whether to include image data URLs in the response (default: false)
 - Returns: Full note content including HTML, comments, attachments, groups, folders and more
 
 ## Local Development

--- a/src/kibela.ts
+++ b/src/kibela.ts
@@ -64,6 +64,11 @@ const GET_NOTE_CONTENT_TOOL: Tool = {
     type: "object",
     properties: {
       id: { type: "string", description: "Note ID" },
+      include_image_data: {
+        type: "boolean",
+        description: "Whether to include image data URLs in the response",
+        default: false,
+      },
     },
     required: ["id"],
   },
@@ -170,6 +175,11 @@ const GET_NOTE_FROM_PATH_TOOL: Tool = {
     type: "object",
     properties: {
       path: { type: "string", description: "Note path (e.g. 'https://${process.env.KIBELA_TEAM}.kibe.la/notes/5154')" },
+      include_image_data: {
+        type: "boolean",
+        description: "Whether to include image data URLs in the response",
+        default: false,
+      },
     },
     required: ["path"],
   },
@@ -326,6 +336,25 @@ export const createServer = () => {
 
         case "kibela_get_note_content": {
           const id = args.id as string;
+          const includeImageData = (args.include_image_data as boolean) || false;
+
+          const attachmentsFragment = includeImageData
+            ? `attachments(first: 3) {
+                  nodes {
+                    id
+                    name
+                    dataUrl
+                    mimeType
+                  }
+                }`
+            : `attachments(first: 3) {
+                  nodes {
+                    id
+                    name
+                    mimeType
+                  }
+                }`;
+
           const operation = `
             query GetNote($id: ID!) {
               note(id: $id) {
@@ -338,14 +367,7 @@ export const createServer = () => {
                 url
                 path
                 isLikedByCurrentUser
-                attachments(first: 3) {
-                  nodes {
-                    id
-                    name
-                    dataUrl
-                    mimeType
-                  }
-                }
+                ${attachmentsFragment}
                 author {
                   id
                   account
@@ -660,8 +682,26 @@ export const createServer = () => {
 
         case "kibela_get_note_from_path": {
           const rawPath = args.path as string;
+          const includeImageData = (args.include_image_data as boolean) || false;
           // Extract path from URL if full URL is provided
           const path = rawPath.includes("kibe.la/notes/") ? `/notes/${rawPath.split("/notes/")[1]}` : rawPath;
+
+          const attachmentsFragment = includeImageData
+            ? `attachments(first: 3) {
+                  nodes {
+                    id
+                    name
+                    dataUrl
+                    mimeType
+                  }
+                }`
+            : `attachments(first: 3) {
+                  nodes {
+                    id
+                    name
+                    mimeType
+                  }
+                }`;
 
           const operation = `            query GetNoteFromPath($path: String!) {
               noteFromPath(path: $path) {
@@ -674,14 +714,7 @@ export const createServer = () => {
                 url
                 path
                 isLikedByCurrentUser
-                attachments(first: 3) {
-                  nodes {
-                    id
-                    name
-                    dataUrl
-                    mimeType
-                  }
-                }
+                ${attachmentsFragment}
                 author {
                   id
                   account

--- a/src/kibela.ts
+++ b/src/kibela.ts
@@ -347,13 +347,7 @@ export const createServer = () => {
                     mimeType
                   }
                 }`
-            : `attachments(first: 3) {
-                  nodes {
-                    id
-                    name
-                    mimeType
-                  }
-                }`;
+            : "";
 
           const operation = `
             query GetNote($id: ID!) {
@@ -695,13 +689,7 @@ export const createServer = () => {
                     mimeType
                   }
                 }`
-            : `attachments(first: 3) {
-                  nodes {
-                    id
-                    name
-                    mimeType
-                  }
-                }`;
+            : "";
 
           const operation = `            query GetNoteFromPath($path: String!) {
               noteFromPath(path: $path) {


### PR DESCRIPTION
## Whats

I've added `include_image_data` properties to `kibela_get_note_content` and `kibela_get_note_from_path` for avoiding heavy context.

## Why

Because I sometimes got error `Your conversation is too long...`  on `kibela_get_note_content` and `kibela_get_note_from_path` using from Cursor + Claude 3.7 sonnet.

<img width="375" alt="image" src="https://github.com/user-attachments/assets/5208e4e4-3410-4e0c-a155-77e5c65ddb43" />

## Result

I tried same query and it works without 'Your conversation is too long...'.